### PR TITLE
Make the publication's sharable URL more friendly

### DIFF
--- a/avocet/css/publication.css
+++ b/avocet/css/publication.css
@@ -18,6 +18,6 @@
     width: 400px;
 }
 
-input.avocet-shareable-link[readonly] {
+#publication-share {
     cursor: auto;
 }

--- a/avocet/js/publication.js
+++ b/avocet/js/publication.js
@@ -61,16 +61,10 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
      * Render the publication metadata.
      */
     var setUpPublicationMetaData = function() {
-        var $container = $('#publication-metadata-container');
-        oae.api.util.template().render($('#publication-metadata-template'), {'publication': publicationProfile}, $container);
-        setUpHighlightingOfShareUrlOnClick($container);
-    };
+        oae.api.util.template().render($('#publication-metadata-template'), {'publication': publicationProfile}, $('#publication-metadata-container'));
 
-    /**
-     * Highlight the share URL text when clicking on its input.
-     */
-    var setUpHighlightingOfShareUrlOnClick = function($container) {
-        $container.on("click", ".avocet-shareable-link", function() {
+        // Highlight the share URL text when clicking on its input
+        $("#publication-share").on("click", function() {
             $(this).select();
         });
     };

--- a/avocet/publication.html
+++ b/avocet/publication.html
@@ -31,7 +31,7 @@
             <form class="form-inline" role="form">
                 <div class="form-group">
                     <label for="publication-share">Share:</label>
-                    <input type="text" id="publication-share" class="form-control avocet-shareable-link" value="${window.location.href}" readonly/>
+                    <input type="text" id="publication-share" class="form-control" value="${window.location.href}" readonly/>
                 </div>
             </form>
         --></div>


### PR DESCRIPTION
The disabled cursor has been removed and the URL text is auto selected
when clicking on the input.

This fixes #36. Also I'm not sure if this publication metadata section should be made into an OAE widget? Seems out of place not being one.
