### PR TITLE
Allow mid-word breaking of filenames without spaces to avoid overflows

### DIFF
--- a/node_modules/oae-avocet/submitpublication/css/submitpublication.css
+++ b/node_modules/oae-avocet/submitpublication/css/submitpublication.css
@@ -48,6 +48,8 @@
 
 #oa-submitpublication-form .oa-submitpublication-details-form-file-heading {
     margin: 0;
+    /* Allow mid-word line breaking of filenames which often lack spaces to use as break points. */
+    word-wrap: break-word;
 }
 
 #oa-submitpublication-form .oa-submitpublication-multi-add input {


### PR DESCRIPTION
Fixes #77.
