### PR TITLE
Footer sticks to the status bar

### DIFF
--- a/node_modules/oae-avocet/submitpublication/css/submitpublication.css
+++ b/node_modules/oae-avocet/submitpublication/css/submitpublication.css
@@ -54,3 +54,7 @@
     display: inline;
     width: auto;
 }
+
+#oa-submitpublication-form {
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
There should be more space between the footer and the browser's bottom status bar.
