### PR TITLE
Note on APC typo

### DIFF
--- a/node_modules/oae-avocet/submitpublication/submitpublication.html
+++ b/node_modules/oae-avocet/submitpublication/submitpublication.html
@@ -124,7 +124,7 @@
             </div>
 
             <div class="panel-heading">
-                <h3 class="panel-title">A note on APC</h3>
+                <h3 class="panel-title">Note on publication fees</h3>
             </div>
 
             <div class="panel-body oa-submitpublication-panel-body">


### PR DESCRIPTION
There is a typo in the note on APC (missing l in details): We will check and get back to you with detais.
