### PR TITLE
Can't select a file from the error uploading file screen

### DIFF
--- a/node_modules/oae-avocet/submitpublication/js/submitpublication.js
+++ b/node_modules/oae-avocet/submitpublication/js/submitpublication.js
@@ -148,14 +148,14 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport'], f
                     var data = $(form).serializeObject();
                     data.funders = fundersComponent.getItems();
                     oae.api.publication.createPublication(data.title, data.author, data.journal, data.funders, data.email, data.copyright, data.comment, $upload, selectedFile, function(error, data) {
+                        // Reset the upload form
+                        resetFileUpload();
                         if (error) {
                             // Go back to the file selection
                             $progress.hide();
                             $upload.show();
                             // Show there was an error
                             showFileUploadError();
-                            // Reset the upload form
-                            resetFileUpload();
                             return;
                         }
                         // Reset the form and the fundersComponent


### PR DESCRIPTION
When I tried to select and upload a different file in Safari from the error uploading file screen I selected the file but it did not seem to upload. I was able to drag and drop a file.
