### PR TITLE
When comments field is expanded using drag handle it gets hidden behind layer on right side of page

### DIFF
--- a/node_modules/oae-avocet/submitpublication/css/submitpublication.css
+++ b/node_modules/oae-avocet/submitpublication/css/submitpublication.css
@@ -42,6 +42,10 @@
     width: 200%;
 }
 
+#oa-submitpublication-form textarea {
+    resize: vertical;
+}
+
 #oa-submitpublication-form .oa-submitpublication-panel-body ~ .oa-submitpublication-panel-body {
     border-top: 1px solid #DDD;
 }


### PR DESCRIPTION
I dragged the handle at the bottom right of the comments field to make it bigger and it got lost behind a layer at the edge of the form. I was unable to read all the text in the field or see the grab handle to make it smaller again.
