### PR TITLE
Navigation dissappears when making screen small

### DIFF
--- a/node_modules/oae-avocet/avocetnavigation/avocetnavigation.html
+++ b/node_modules/oae-avocet/avocetnavigation/avocetnavigation.html
@@ -1,6 +1,6 @@
 <div class="container">
     <nav class="navbar navbar-default" role="navigation">
-        <div class="collapse navbar-collapse">
+        <div class="navbar-collapse">
             <ul id="oa-avocetnavigation-container" class="nav navbar-nav"><!-- --></ul>
             <a href="/me" class="btn btn-success navbar-btn pull-right">Upload</a>
         </div>


### PR DESCRIPTION
When I make the screen quite small (smartphone size), the navigation isn't visible anymore.

Screenshot taken via my phone, but can be approximated by altering browser width. Acknowledge that we are not making this responsive, but users using mobile devices this seems a less than satisfactory experience. Would it be advisable to hide if user is altering width to a small view or using a mobile?

![screenshot_2014-04-01-10-07-43](https://cloud.githubusercontent.com/assets/6153363/2577249/69bdea9a-b97d-11e3-83de-17f1726f7714.png)
