### PR TITLE
Funder errors not displayed correctly

### DIFF
--- a/node_modules/oae-avocet/publicationform/js/publicationform.js
+++ b/node_modules/oae-avocet/publicationform/js/publicationform.js
@@ -91,11 +91,6 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.typeahead', 'bootstrap.datep
                         'oa-validate-other-funders': true
                     }
                 },
-                'errorPlacement': function($error, $element) {
-                    var $parent = $element.parent();
-                    // If the input's parent is a '.input-group', insert the error after the input group, otherwise insert it directly after the input element
-                    $error.insertAfter($parent.hasClass('input-group') ? $parent : $element);
-                },
                 'submitHandler': function(form) {
                     var data = $(form).serializeObject();
                     // Ensure data.funders is an Array

--- a/node_modules/oae-avocet/publicationform/publicationform.html
+++ b/node_modules/oae-avocet/publicationform/publicationform.html
@@ -44,6 +44,7 @@
                         <input id="input-acceptancedate" class="form-control" name="acceptanceDate" type="text" placeholder="DD/MM/YYYY">
                         <span class="input-group-addon oa-publicationform-trigger-datepicker"><i class="icon-calendar"><span class="sr-only">Datepicker</span></i></span>
                     </div>
+                    <div class="help"><!-- --></div>
                     <button data-toggle="modal" data-target="#oa-submitpublication-acceptance-modal" type="button" class="oa-inline-btn-link btn btn-link">Find out more</button>
                 </div>
             </div>


### PR DESCRIPTION
When there is an error with the funders while filling out the publication form, the error shows up in the wrong place.

![screen shot 2014-04-25 at 10 53 48](https://cloud.githubusercontent.com/assets/1674142/2799436/b19a46de-cc5f-11e3-9471-d53992882375.png)
