### PR TITLE
Fix firefox sign in not working

### DIFF
--- a/shared/oae/api/oae.api.authentication.js
+++ b/shared/oae/api/oae.api.authentication.js
@@ -85,7 +85,7 @@ define(['exports', 'jquery', 'oae.api.config'], function(exports, $, configAPI) 
         }
 
         // Set up and submit a form which posts to the strategy url
-        var $form = $('<form method="post"></form>').attr('action', loginUrl);
+        var $form = $('<form class="hide" method="post"></form>').attr('action', loginUrl).appendTo('body');
         $('<input type="hidden" name="redirectUrl" />').val(_getLoginRedirectURL()).appendTo($form);
         $form.submit();
     };


### PR DESCRIPTION
The login issue in firefox is fixed by appending the sign in form to the body before submitting it (Firefox Fix)
