### PR TITLE
Show error page when a publication is not found

### DIFF
--- a/avocet/js/publication.js
+++ b/avocet/js/publication.js
@@ -29,6 +29,10 @@ define(['jquery', 'oae.core', 'globalize'], function($, oae) {
      */
     var setUpSubmissionProfile = function() {
         oae.api.publication.getPublication(publicationId, function(err, publication) {
+            if (err) {
+                oae.api.util.redirect().notfound();
+            }
+
             // Cache the publication profile data
             publicationProfile = publication;
             // Set the browser title


### PR DESCRIPTION
When a publication is not found, the user is redirected to the "not found" error page. If some other error occurred, we redirect the user to the "unavailable" error page.
