### PR TITLE
Zendesk acceptance date

### DIFF
--- a/avocet/js/publication.js
+++ b/avocet/js/publication.js
@@ -82,11 +82,16 @@ define(['jquery', 'oae.core', 'globalize'], function($, oae) {
             // Remove the 'other:' part from the string
             return otherFunder.substr(6);
         }).join(', ');
+
         // Default the acceptance date to an empty string
         var acceptanceDateString = '';
+        // If an acceptance date is set, convert it to DD/MM/YYYY format
         if (publication.acceptanceDate !== null) {
-            // If an acceptance date is set, convert it to DD/MM/YYYY format
-            var acceptanceDateString = Globalize.format(new Date(publication.acceptanceDate), 'd', 'en-GB');
+            // acceptanceDate is a millisecond timestamp representing the date in UTC. We need obtain the local time equivalent of this time in order to have Globalize.format() format it (as you can't tell Globalize to format the UTC representation)
+            var dateUTC = new Date(publication.acceptanceDate);
+            var dateLocal = new Date(dateUTC.getUTCFullYear(), dateUTC.getUTCMonth(), dateUTC.getUTCDate());
+
+            var acceptanceDateString = Globalize.format(dateLocal, 'd', 'en-GB');
         }
 
         return {

--- a/node_modules/oae-avocet/publicationform/js/publicationform.js
+++ b/node_modules/oae-avocet/publicationform/js/publicationform.js
@@ -109,7 +109,10 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.typeahead', 'bootstrap.datep
 
                     // Convert the acceptance date to millieseconds
                     var acceptanceDate = Globalize.parseDate(data['acceptanceDate'], 'dd/MM/yyyy');
-                    data['acceptanceDate'] = acceptanceDate.valueOf();
+
+                    // acceptanceDate is currently in local time. We need to send the UTC equivalent of the local date @ midnight (as a millisecond timestamp).
+                    data['acceptanceDate'] = Date.UTC(acceptanceDate.getFullYear(), acceptanceDate.getMonth(), acceptanceDate.getDate());
+
                     // Dispatch an event if the form is submitted
                     $(document).trigger('oa.publicationform.submit', data);
                 }


### PR DESCRIPTION
Setting 01/04/2013 as my acceptance date results to 31/03/2013 in the generated zendesk ticket. When viewing my upload in the UI the acceptance date is still shown as 01/04/2014

(Timezone issue, need to get date in UTC in browser before sending timestamp to server: date.setMinutes(-date.getTimezoneOffset()) -Hal)
