### PR TITLE
Send and receive publication acceptanceDate as UTC

### DIFF
--- a/avocet/js/publication.js
+++ b/avocet/js/publication.js
@@ -86,11 +86,16 @@ define(['jquery', 'oae.core', 'globalize'], function($, oae) {
             // Remove the 'other:' part from the string
             return otherFunder.substr(6);
         }).join(', ');
+
         // Default the acceptance date to an empty string
         var acceptanceDateString = '';
+        // If an acceptance date is set, convert it to DD/MM/YYYY format
         if (publication.acceptanceDate !== null) {
-            // If an acceptance date is set, convert it to DD/MM/YYYY format
-            var acceptanceDateString = Globalize.format(new Date(publication.acceptanceDate), 'd', 'en-GB');
+            // acceptanceDate is a millisecond timestamp representing the date in UTC. We need obtain the local time equivalent of this time in order to have Globalize.format() format it (as you can't tell Globalize to format the UTC representation)
+            var dateUTC = new Date(publication.acceptanceDate);
+            var dateLocal = new Date(dateUTC.getUTCFullYear(), dateUTC.getUTCMonth(), dateUTC.getUTCDate());
+
+            var acceptanceDateString = Globalize.format(dateLocal, 'd', 'en-GB');
         }
 
         return {

--- a/node_modules/oae-avocet/publicationform/js/publicationform.js
+++ b/node_modules/oae-avocet/publicationform/js/publicationform.js
@@ -110,7 +110,8 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.typeahead', 'bootstrap.datep
                     // Convert the acceptance date to millieseconds
                     var acceptanceDate = Globalize.parseDate(data['acceptanceDate'], 'dd/MM/yyyy');
                     if (acceptanceDate) {
-                        data['acceptanceDate'] = acceptanceDate.valueOf();
+                        // acceptanceDate is currently in local time. We need to send the UTC equivalent of the local date @ midnight (as a millisecond timestamp).
+                        data['acceptanceDate'] = Date.UTC(acceptanceDate.getFullYear(), acceptanceDate.getMonth(), acceptanceDate.getDate());
                     }
 
                     // Dispatch an event if the form is submitted


### PR DESCRIPTION
The date is sent as the date @ midnight UTC and converted from UTC back
to local time on recept.

(Replacement for https://github.com/CUL-DigitalServices/avocet-ui/pull/134)
