### PR TITLE
Google fonts should be loaded protocol agnostic

### DIFF
--- a/avocet/css/avocet.fonts.css
+++ b/avocet/css/avocet.fonts.css
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-@import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
+@import url('//fonts.googleapis.com/css?family=PT+Sans:400,700');
 
 body, button, input, select, textarea, h1, h2, h3, h4, h5, h6 {
     font-family: 'PT Sans', 'Myriad Pro', arial, helvetica, sans-serif;


### PR DESCRIPTION
In avocet/css/avocet.fonts.css we load the google fonts over http where we should be protocol agnostic e.g., //fonts.googleapis.com...

Assigning to @timdegroote 
