### PR TITLE
Tweak to home page copy

### DIFF
--- a/avocet/index.html
+++ b/avocet/index.html
@@ -14,7 +14,7 @@
 
             <header class="oa-home-banner oa-panel-primary">
                 <div class="container">
-                    <h2>Accepted for publication? Make sure your work is eligible for the REF</h2>
+                    <h2>Accepted for publication? Make sure your work can be eligible for the REF</h2>
                     <a href="/me" class="btn oa-btn-upload oa-btn-primary" title="Go to the manuscript upload page">Upload manuscript</a>
                 </div>
             </header>


### PR DESCRIPTION
Could we modify the 1st line of home page copy very slightly? E.g.

Accepted for publication? Make sure your work is eligible for the REF

should be changed to:

Accepted for publication? Make sure your work can be eligible for the REF

E.g. change the word 'is' to 'can be'.

If this can go in before the launch it would be good, to make sure the message is not confusing but still has the same emphasis.
