### PR TITLE
Acceptance date manual entry

### DIFF
--- a/node_modules/oae-avocet/publicationform/js/publicationform.js
+++ b/node_modules/oae-avocet/publicationform/js/publicationform.js
@@ -149,11 +149,24 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.typeahead', 'bootstrap.datep
                 // Initialise typeahead functionality on the journal and department fields
                 initTypeahead($('#oa-publicationform-input-journal', $rootel), 'journals', '/api/search/journals');
                 initTypeahead($('#oa-publicationform-input-department', $rootel), 'departments', '/api/search/departments');
+
+                // Custom datepicker 'enter' event
+                $('.input-group.date', $rootel).find('input').on('keydown keyup', function(e) {
+                    if (e.keyCode === 13) {
+                        // Prevent the datepicker event handler to be triggered
+                        e.stopImmediatePropagation();
+                        // Hide the datepicker element (also sets the selected date as the value for the input field)
+                        $('.input-group.date', $rootel).datepicker('hide');
+                        return false;
+                    }
+                });
+
                 // Initialise the datepicker
                 $('.input-group.date', $rootel).datepicker({
                     'format': 'dd/mm/yyyy',
                     'keyboardNavigation': false
                 });
+
                 // Initialise form validation
                 initFormValidation();
             } else {


### PR DESCRIPTION
If you enter acceptance date manually and hit return the date typed is not saved and the field defaults to being empty. When you manually enter the date a date is selected in the calendar. If you click it the field is cleared.
