### PR TITLE
Wellcome Trust policy wording 

### DIFF
--- a/avocet/changing.html
+++ b/avocet/changing.html
@@ -90,7 +90,7 @@
                         <header>
                             <h4>The Wellcome Trust</h4>
                         </header>
-                        <p>Wellcome Trust Grant Conditions require that all research papers funded in whole or in part through the Europe PubMed Central (Europe PMC) or PubMed Central (PMC) should be available with an electronic copy in a repository as soon as possible or within six months of publication. This applies to all research papers that have been submitted and accepted for publication in a peer reviewed journal.</p>
+                        <p>Wellcome Trust grant conditions require that all wholly or partly Wellcome-funded research papers should be available in the Europe PubMed Central (Europe PMC) or PubMed Central (PMC) repositories as soon as possible, or within six months of publication. This applies to all research papers that have been submitted and accepted for publication in a peer-reviewed journal.</p>
                         <a href="http://www.wellcome.ac.uk/stellent/groups/corporatesite/%40policy_communications/documents/web_document/WTVM050569.pdf" target="_blank" title="Read more about the The Wellcome Trust open access policy on the The Wellcome Trust website">Read more about the The Wellcome Trust open access policy <i class="icon-external-link oa-icon-normal"></i></a>
                     </article>
                 </div>


### PR DESCRIPTION
The section on the Wellcome Trust policy at the bottom of the 'What's Changing?' page wrongly talks about 'research papers funded in whole or in part through the Europe PubMed Central (Europe PMC) or PubMed Central (PMC)'.

The papers aren't funded by PMC, they're funded by Wellcome. PMC is the name of the repository. It should read:

Wellcome Trust grant conditions require that all wholly or partly Wellcome-funded research papers should be available in the Europe PubMed Central (Europe PMC) or PubMed Central (PMC) repositories as soon as possible, or within six months of publication. This applies to all research papers that have been submitted and accepted for publication in a peer-reviewed journal.
