### PR TITLE
Gramatical errors in What Do I Need To Do and What's Changing pages

### DIFF
--- a/avocet/todo.html
+++ b/avocet/todo.html
@@ -146,26 +146,26 @@
                     <header>
                         <h3>Licensing</h3>
                     </header>
-                    <p>As well as copyright, different funders and publishers adhere to a range of licensing agreements. Licenses affect how your work can be copied, distributed, shared and how others can use it, commercially and non-commercially.</p>
+                    <p>As well as copyright, different funders and publishers adhere to a range of licensing agreements. Licences affect how your work can be copied, distributed, shared and how others can use it, commercially and non-commercially.</p>
                     <article>
                         <header>
                             <h4>CC BY</h4>
                         </header>
-                        <p>This license lets others distribute, remix, tweak and build upon your work, including commercially, as long as they credit you for the original creation.</p>
+                        <p>This licence lets others distribute, remix, tweak and build upon your work, including commercially, as long as they credit you for the original creation.</p>
                     </article>
 
                     <article>
                         <header>
                             <h4>CC BY-NC</h4>
                         </header>
-                        <p>This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.</p>
+                        <p>This licence lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.</p>
                     </article>
 
                     <article>
                         <header>
                             <h4>CC BY-NC-ND</h4>
                         </header>
-                        <p>This license is the most restrictive, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.</p>
+                        <p>This licence is the most restrictive, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.</p>
                     </article>
                 </div>
             </section>
@@ -183,7 +183,7 @@
                         <li>multiple grant numbers should be separated by a comma and space</li>
                         <li>funding agencies should be separated by a semi-colon.</li>
                     </ul>
-                    <p>eg. 'This work was supported by the Wellcome Trust [grant number], [grant number]; Medical Research Council [grant number] and Cancer Research UK [grant number]<br>If you have any queries or require guidance then please <a href="mailto:info@openaccess.cam.ac.uk" title="__MSG__CONTACT_US_VIA_EMAIL__">contact us</a>.</p>
+                    <p>e.g., 'This work was supported by the Wellcome Trust [grant number], [grant number]; Medical Research Council [grant number] and Cancer Research UK [grant number]<br>If you have any queries or require guidance then please <a href="mailto:info@openaccess.cam.ac.uk" title="__MSG__CONTACT_US_VIA_EMAIL__">contact us</a>.</p>
 
                     <p><a href="http://rinarchive.jisc-collections.ac.uk/our-work/research-funding-policy-and-guidance/acknowledgement-funders-journal-articles" target="_blank" title="Read full details of the RIN guidelines on the RIN website">Read full details of the RIN guidelines <i class="icon-external-link oa-icon-normal"></i></a></p>
                 </div>


### PR DESCRIPTION
Philip has noticed some incorrect spellings, particularly around the use of the licence/license and which version to use depending on whether it is a verb or a noun. 

There is also a change to the format of the e.g. at the bottom of the the "What Do I Need To Do" page (it should be e.g.). 

I've annotated some print outs with the changes (see me to run through). 
