### PR TITLE
Only import the required oae css files instead of importing oae.core.css fully

### DIFF
--- a/avocet/css/avocet.css
+++ b/avocet/css/avocet.css
@@ -12,8 +12,17 @@
  * or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-/* Import the base OAE styles */
-@import url('../../shared/oae/css/oae.core.css');
+
+/* Import the Bootstrap CSS file */
+@import url('../../shared/vendor/css/bootstrap.css');
+/* Import the Font Awesome Icon Set */
+@import url('../../shared/vendor/css/font-awesome/css/font-awesome.css');
+/* Import the OAE Core styles. These will be used for bootstrap overrides, as well
+   as styles used in the main portal that are not expected to be re-used in widgets */
+@import url('../../shared/oae/css/oae.base.css');
+/* Import the OAE Component Styles. These contain OAE specific re-usable styles that,
+   combined with basic bootstrap, should make it easy to quickly put new widgets together */
+@import url('../../shared/oae/css/oae.components.css');
 /* Import the skin file */
 @import url('avocet.skin.css');
 /* Import the fonts file */


### PR DESCRIPTION
This removes font/css file imports from `oae.core.css` which aren't needed for avocet.
