### PR TITLE
Meta-description for home page

### DIFF
--- a/avocet/index.html
+++ b/avocet/index.html
@@ -3,6 +3,7 @@
     <head>
         <title>Open Access at Cambridge</title>
         <meta name="viewport" content="width=device-width">
+        <meta name="description" content="A service which helps University of Cambridge researchers meet HEFCE and funder Open Access policy requirements.">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <noscript>


### PR DESCRIPTION
At the moment Google is using the navigation as the description of our home page. 

![screenshot 2014-05-23 13 42 17](https://cloud.githubusercontent.com/assets/1784932/3066616/cd8c5a70-e277-11e3-935a-bd66fea12027.png)

Please can we add the meta-description tag in the header with the following text:

"A service which helps University of Cambridge researchers meet HEFCE and funder Open Access policy requirements."
