### PR TITLE
APC Payments

### DIFF
--- a/node_modules/oae-avocet/publicationform/bundles/default.properties
+++ b/node_modules/oae-avocet/publicationform/bundles/default.properties
@@ -1,4 +1,4 @@
-A_NOTE_ON_OPEN_ACCESS_FEES = A note on Open Access fees
+A_NOTE_ON_OPEN_ACCESS_CHARGES = A note on Open Access charges
 ACCEPTANCE_DATE = Acceptance date
 AHRC = AHRC
 ARTS_AND_HUMANITIES_RESEARCH_COUNCIL = Arts &amp; Humanities Research Council

--- a/node_modules/oae-avocet/publicationform/publicationform.html
+++ b/node_modules/oae-avocet/publicationform/publicationform.html
@@ -174,7 +174,7 @@
         <div class="oa-section oa-form-section oa-form-note">
             <div class="container">
                 <p>
-                    <button data-toggle="modal" data-target="#oa-submitpublication-apc-modal" type="button" class="btn oa-link oa-btn-link oa-inline-btn-link">__MSG__A_NOTE_ON_OPEN_ACCESS_FEES__</button>
+                    <button data-toggle="modal" data-target="#oa-submitpublication-apc-modal" type="button" class="btn oa-link oa-btn-link oa-inline-btn-link">__MSG__A_NOTE_ON_OPEN_ACCESS_CHARGES__</button>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
- Wording on APC modal on upload screen - Needs a link to information, or more copy in the modal. "To ensure your work is eligible for REF, please upload your manuscript.
  Find out how we can help with Article Processing Charges (APC) payments."
- Need to pay publisher's fee modal not sufficient? - The modal for 'Need to pay a publisher's fee' needs a bit more wording, or a link to the content pages.
