### PR TITLE
Restructure the header's expandable nav

### DIFF
--- a/avocet/css/avocet.skin.css
+++ b/avocet/css/avocet.skin.css
@@ -147,6 +147,7 @@
 .oa-site-header a,
 .oa-site-header a:focus,
 .oa-site-header a:hover,
+.oa-site-header .oa-nav-item,
 .oa-site-header button,
 .oa-site-header button:active,
 .oa-site-header button:focus,
@@ -155,7 +156,7 @@
     color: #FFF;
 }
 
-.oa-site-header .oa-nav a {
+.oa-site-header .oa-nav .oa-nav-item {
     border-bottom-color: transparent;
 }
 
@@ -163,20 +164,26 @@
     background: #F7F5F2;
 }
 
-.oa-site-header .oa-subnav a {
+.oa-site-header .oa-nav:not(.depth-1) .oa-nav-item,
+.oa-site-header .oa-subnav .oa-nav-item {
     color: #323232;
 }
 
-.oa-site-header .oa-nav a:hover,
-.oa-site-header .oa-nav a:focus,
-.oa-site-header .oa-nav a.active {
+.oa-site-header .oa-nav .oa-nav-item:hover,
+.oa-site-header .oa-nav .oa-nav-item:focus,
+.oa-site-header .oa-nav .oa-nav-item.active {
     border-bottom-color: #CBCBCB;
 }
 
-.oa-site-header .oa-subnav a:hover,
-.oa-site-header .oa-subnav a.active {
+.oa-site-header .oa-nav:not(.depth-1) .oa-nav-item:hover,
+
+.oa-site-header .oa-subnav .oa-nav-item:hover,
+.oa-site-header .oa-subnav .oa-nav-item.active {
     border-bottom-color: #575A5D;
     color: #575A5D;
+}
+.oa-site-header .oa-nav-item a {
+    color: inherit;
 }
 
 /*****************

--- a/node_modules/oae-avocet/avocetheader/avocetheader.html
+++ b/node_modules/oae-avocet/avocetheader/avocetheader.html
@@ -1,25 +1,22 @@
 <!-- CSS -->
 <link rel="stylesheet" type="text/css" href="css/avocetheader.css" />
 
-<header id="oa-avocetheader" class="oa-site-header">
+<header id="oa-avocetheader" class="oa-site-header" data-tab-first=".oa-btn-uni" data-tab-last="">
+    <div id="oa-avocetheader-nav-container" class=""><!-- --></div>
     <div class="container">
         <div class="row">
             <div class="col-xs-6">
                 <div class="row">
                     <div class="col-xs-6">
-                        <a class="oa-btn-uni" href="http://www.cam.ac.uk/" target="_blank" title="__MSG__UNIVERSITY_OF_CAMBRIDGE_HOME__">
+                        <a tabindex="1" class="oa-btn-uni" href="http://www.cam.ac.uk/" target="_blank" title="__MSG__UNIVERSITY_OF_CAMBRIDGE_HOME__" data-tab-prev=":block:">
                             <img src="/avocet/images/main-logo.png" alt="__MSG__UNIVERSITY_OF_CAMBRIDGE__" />
                         </a>
                     </div>
-                    <nav id="oa-avocetheader-nav-container" class="col-xs-6 oa-nav"><!-- --></nav>
                 </div>
             </div>
 
             <div id="oa-avocetheader-authentication-container" class="col-xs-6 text-right"><!-- --></div>
         </div>
-    </div>
-    <div class="oa-subnav">
-        <div class="oa-nav" id="oa-avocetheader-subnav-container"><!-- --></div>
     </div>
 </header>
 
@@ -35,21 +32,25 @@
 --></div>
 
 <div id="oa-avocetheader-nav-template"><!--
-    {for link in links}
-        <a href="${link.href}" {if link.href === activeNavLink}class="active"{/if} {if link.subLinks && link.href !== activeNavLink}data-toggle-subnav="#oa-avocetheader-subnav-${link.title}"{/if} title="Open the '${link.title}' page">${link.title}</a>
-    {/for}
---></div>
+    {macro renderNavList(navs, depth)}
+        {if navs.length}
+            <div class="oa-nav depth-${depth}">
+                <div class="oa-nav-items">
+                    {for nav in navs}
+                        <div class="${['oa-nav-item', nav.isActive() || nav.hasActiveChild() ? 'active' : ''].join(' ')}">
+                            <a href="${nav.href()}" title="${nav.title()}">
+                                ${nav.name()}
+                            </a>
 
-<div id="oa-avocetheader-subnav-template"><!--
-    {for link in links}
-        <nav id="oa-avocetheader-subnav-${link.title}" {if activeNavLink === link.href}class="oa-subnav-active"{/if}>
-            <div class="container">
-                {for subLink in link.subLinks}
-                    <a href="${subLink.href}" {if subLink.href === activePage}class="active"{/if} title="Open the '${subLink.title}' page">${subLink.title}</a>
-                {/for}
+                            ${renderNavList(nav.children(), depth + 1)}
+                        </div>
+                    {/for}
+                </div>
             </div>
-        </nav>
-    {/for}
+        {/if}
+    {/macro}
+
+    ${renderNavList(navs, 1)}
 --></div>
 
 <!-- JAVASCRIPT -->

--- a/node_modules/oae-avocet/avocetheader/css/avocetheader.css
+++ b/node_modules/oae-avocet/avocetheader/css/avocetheader.css
@@ -16,33 +16,79 @@
 /****************
  ** Navigation **
  ****************/
-#oa-avocetheader .oa-nav a {
+
+/* Fix z ordering: the nav needs to be above the header and
+   the other header buttons need to be above the nav. */
+#oa-avocetheader .oa-nav.depth-1 {
+    z-index: 1;
+}
+#oa-avocetheader .oa-btn-uni,
+#oa-avocetheader #oa-avocetheader-authentication-container > * {
+    z-index: 2;
+    position: relative;
+}
+
+#oa-avocetheader {
+    /* This is the offset parent for .oa-nav.depth-1 */
+    position: relative;
+}
+
+#oa-avocetheader .oa-nav-items {
+    /* @extend .container */
+    width: 960px;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+}
+
+#oa-avocetheader .oa-nav {
+    background-color: #F7F5F2;
+    left: 0;
+    position: absolute;
+    top: 68px;
+    width: 100%;
+}
+#oa-avocetheader .oa-nav.depth-1 {
+    background: none;
+    top: 0;
+    /* Offset the first line to the right of the uni logo. */
+    left: 240px;
+}
+#oa-avocetheader .oa-nav.depth-2 {
+    /* reset the effects of offsetting .depth-1 */
+    left: -240px;
+}
+
+#oa-avocetheader .oa-nav:not(.depth-1) > .oa-nav-items {
+    height: 0;
+    overflow: hidden;
+    transition: height .3s;
+    visibility: hidden; /* Prevent elements from being focused */
+}
+
+#oa-avocetheader .oa-nav-item.viewed > .oa-nav > .oa-nav-items,
+#oa-avocetheader .oa-nav-item.active > .oa-nav > .oa-nav-items {
+    height: 68px;
+    visibility: visible;
+}
+
+#oa-avocetheader .oa-nav .oa-nav-item {
     border-bottom-style: solid;
     border-bottom-width: 5px;
     display: inline-block;
     font-size: 18px;
-    margin: 0 90px 0 0;
-    padding: 22px 0 14px 0;
+    margin: 0 80px 0 0;
 }
-
-#oa-avocetheader .oa-nav a:last-child {
+#oa-avocetheader .oa-nav .oa-nav-item:last-child {
     margin-right: 0;
 }
 
-#oa-avocetheader .oa-nav a:hover,
-#oa-avocetheader .oa-nav a:focus,
-#oa-avocetheader .oa-nav a.active {
-    margin-bottom: 0;
-}
-
-#oa-avocetheader .oa-subnav nav {
-    height: 0;
-    overflow: hidden;
-    transition: height .3s;
-}
-
-#oa-avocetheader .oa-subnav nav.oa-subnav-active {
-    height: 68px;
+#oa-avocetheader .oa-nav .oa-nav-item a {
+    display: inline-block; /* Required for padding */
+    /* offset the focus halo inside the bounding box to avoid clipping due to overflow: hidden;  */
+    outline-offset: -5px;
+    padding: 22px 5px 14px 5px;
 }
 
 /******************

--- a/node_modules/oae-avocet/avocetheader/js/avocetheader.js
+++ b/node_modules/oae-avocet/avocetheader/js/avocetheader.js
@@ -15,93 +15,204 @@
 
  define(['jquery', 'oae.core'], function($, oae) {
 
+    // Delay (in milliseconds) to wait before closing the whole nav when the mouse leaves the header
+    var NAV_CLOSE_DELAY = 500;
+
+    // Delay (in milliseconds) to wait before opening a sub nav after mouse over
+    var NAV_OPEN_DELAY = 150;
+
+    /** Represents an item in the header's navigation. */
+    var Nav = function Nav(href, name, children) {
+        // Allow calling Nav without new
+        var self = this instanceof Nav ? this : Object.create(Nav.prototype);
+
+        self._href = href;
+        self._name = name;
+        self._children = children;
+
+        return self;
+    };
+
+    // Define Nav's methods
+    _.extend(Nav.prototype, {
+         /** Get an Array containing this Nav, child Navs, their children etc. */
+        'descendents': function descendents(dest) {
+            if (dest === undefined) dest = [];
+
+            dest.push(this);
+            for (var i in this._children) {
+                this._children[i].descendents(dest);
+            }
+            return dest;
+        },
+
+        /** Get the nearest descendet Nav with a defined href. */
+        '_findHrefNav': function _findHrefNav() {
+            return _.find(this.descendents(), function(x) {
+                return Boolean(x._href);
+            });
+        },
+
+        'href': function href() {
+            var link = this._findHrefNav();
+            return link === undefined ? null : link._href;
+        },
+
+        /** Get the human readable name of the Nav. */
+        'name': function name() {
+            return this._name;
+        },
+
+        'title': function title() {
+            var link = this._findHrefNav();
+            return link === undefined ? null :
+                    'Open the \'' + link.name() + '\' page';
+        },
+
+        /** Get an Array of this Nav's immediate children Navs */
+        'children': function children() {
+            return this._children;
+        },
+
+        /** A Nav is active if it's href is the same as the current page's path. */
+        'isActive': function isActive(urlPath) {
+            if (urlPath === undefined) {
+                urlPath = window.location.pathname;
+            }
+
+            return this.href() === urlPath;
+        },
+
+        'hasActiveChild': function hasActiveChild(urlPath) {
+            var active = _.find(this.descendents(), function(nav) {
+                return nav.isActive(urlPath);
+            });
+            return active !== undefined && active !== this;
+        }
+    });
+
+    // Add static methods
+    _.extend(Nav, {
+        /** Get an Array of Navs from a (parsed) JSON Array of links. */
+        '_fromJSONArray': function fromJSONArray(links) {
+            return _.map(links, function(link) {
+                return new Nav(
+                    link.href,
+                    link.name,
+                    Nav._fromJSONArray(link.subNavs, true)
+                );
+            });
+        },
+
+        /** Get a root Nav containing Navs from a (parsed) JSON Array of links. */
+        'fromJSON': function fromJSON(links) {
+            return new Nav(null, 'ROOT', Nav._fromJSONArray(links));
+        }
+    });
+
     return function(uid) {
 
         // The widget container
         var $rootel = $('#' + uid);
 
-        var activePage = window.location.pathname;
         var links = [
             {
                 'href': '/',
-                'title': 'Home'
+                'name': 'Home'
             },
             {
-                'href': '/what-do-i-need-to-do',
-                'title': 'About',
-                'subLinks': [
+                'name': 'About',
+                'subNavs': [
                     {
                         'href': '/what-do-i-need-to-do',
-                        'title': 'What do I need to do?'
+                        'name': 'What do I need to do?'
                     },
                     {
                         'href': '/what-is-changing',
-                        'title': 'What\'s changing?'
+                        'name': 'What\'s changing?'
                     },
                     {
                         'href': '/what-is-open-access',
-                        'title': 'What is open access?'
+                        'name': 'What is open access?'
                     }
                 ]
             }
         ];
 
+        var rootNav = Nav.fromJSON(links);
+        var navContainer = $('#oa-avocetheader-nav-container', $rootel);
+
         /**
          * Initialise the top navigation
          */
         var initNavigation = function() {
-            // Gets the active link from the links array, if a sublink is currently active it returns the parent link
-            var activeNavItem = _.find(links, function(link) {
-                return link.href === activePage || _.find(link.subLinks, function(subLink) {
-                    return subLink.href === activePage;
-                });
-            });
 
             oae.api.util.template().render($('#oa-avocetheader-nav-template', $rootel), {
-                'activeNavLink': activeNavItem ? activeNavItem.href : null,
-                'links': links
-            }, $('#oa-avocetheader-nav-container', $rootel));
+                'navs': rootNav.children()
+            }, navContainer);
 
-            oae.api.util.template().render($('#oa-avocetheader-subnav-template', $rootel), {
-                'activePage': activePage,
-                'activeNavLink': activeNavItem ? activeNavItem.href : null,
-                // Only supply links which have sublinks defined to the template
-                'links': _.filter(links, function(link) {
-                    return link.subLinks;
-                })
-            }, $('#oa-avocetheader-subnav-container', $rootel));
 
-            // Cache the currently active subnavigation if there is one
-            var $activeSubnav = $('.oa-subnav-active', $rootel);
+            // Open a subnav when:
+            //   a) Its label is hovered for NAV_OPEN_DELAY
+            //   b) Its label is focused (no delay)
+            navContainer.on('mouseenter focus', '.oa-nav-item > a', (function(delay) {
+                var timeoutId;
 
-            // Resets the subnavigation to its original state
-            var resetSubnavigation = function() {
-                $('.oa-subnav-active', $rootel).removeClass('oa-subnav-active');
-                $activeSubnav.addClass('oa-subnav-active');
-            };
+                return function(e) {
+                    // When focusing with keyboard, open the nav item without delay
+                    var actualDelay = e.type === 'focus' ? 0 : delay;
 
-            $('#oa-avocetheader-nav-container a', $rootel).on('mouseenter focus', function() {
-                var $el = $(this);
-                var subnavSelector = $el.data('toggle-subnav');
-                // Toogle the subnavigation for this navigation item if one is specified
-                if (subnavSelector) {
-                    $('.oa-subnav-active', $rootel).removeClass('oa-subnav-active');
-                    $(subnavSelector, $rootel).addClass('oa-subnav-active');
-                } else if ($('[data-toggle-subnav]:focus', $rootel).length === 0) {
-                    // Only reset the subnavigation if a link with subitems doesn't have focus
-                    resetSubnavigation();
+                    // Cancel any pending view action on this or another nav
+                    window.clearTimeout(timeoutId);
+
+                    // View the nav after our delay
+                    timeoutId = window.setTimeout(function() {
+                        var nav = $(e.target).parent('.oa-nav-item')[0];
+                        viewNav(nav);
+                    }, actualDelay);
+                };
+            })(NAV_OPEN_DELAY));
+
+            // Close the nav when the mouse leaves the header for longer than NAV_CLOSE_DELAY 
+            $rootel.on('mouseleave mouseenter', (function(delay) {
+                var timeoutId;
+
+                return function(e) {
+                    if(e.type === 'mouseleave') {
+                        timeoutId = setTimeout(stopViewing, delay);
+                    }
+                    else if(e.type === 'mouseenter') {
+                        window.clearTimeout(timeoutId);
+                    }
+                };
+            })(NAV_CLOSE_DELAY));
+
+            // Close the nav when anything outside the nav is focused in the header
+            $rootel.on('focusin', function(e) {
+                if (!_.contains($(e.target).parents(), navContainer[0])) {
+                    stopViewing();
                 }
             });
+        };
 
-            // Reset the subnavigation to its original state when the mouse leaves the header and/or when the header loses focus
-            $rootel.on('mouseleave focusout', function() {
-                // Wait until the next element has gained focus before checking whether keyboard focus is still inside the header
-                _.defer(function() {
-                    if ($(':focus', $rootel).length === 0) {
-                        resetSubnavigation();
-                    }
-                });
-            });
+        /** Set a nav DOM element as being viewed. */
+        var viewNav = function viewNav(nav) {
+            if (!(nav instanceof Element))
+                throw new Error('Element expected');
+
+            stopViewing();
+            var navs = $(nav).parents('.oa-nav-item').andSelf();
+            navs.addClass('viewed');
+        };
+
+        /**
+         * Clear the the viewed status of all navs.
+         *
+         * This has the effect of closing the nav, unless the active page is in a sub nav,
+         * in which case it'll remain open.
+         */
+        var stopViewing = function stopViewing() {
+            $('.oa-nav-item', $rootel).removeClass('viewed');
         };
 
         /**


### PR DESCRIPTION
The tab order of the nav needed to flow into subnavs after the nav
housing the subnav. To achieve this the HTML was restructured to
have subnavs as children of their parents (e.g. a tree).

Some logic was pulled from the templates from into the Nav class.
