### PR TITLE
Manuscript title links on My Uploads should be orange

### DIFF
--- a/avocet/css/avocet.skin.css
+++ b/avocet/css/avocet.skin.css
@@ -291,15 +291,6 @@
     color: #575A5D;
 }
 
-.oa-myuploads-metadata h4 a {
-    color: #106470;
-}
-
-.oa-myuploads-metadata h4 a:focus,
-.oa-myuploads-metadata h4 a:hover {
-    color: #70A2A9;
-}
-
 .oa-myuploads-metadata span {
     color: #8E908F;
 }


### PR DESCRIPTION
Currently they are the same colour as the title (teal) and not obviously a link. Users haven't found the publication details page in usability tests.
