### PR TITLE
Reducing the size of the comments box on the form obscures text

### DIFF
--- a/node_modules/oae-avocet/publicationform/css/publicationform.css
+++ b/node_modules/oae-avocet/publicationform/css/publicationform.css
@@ -13,16 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#oa-submitpublication-form textarea {
-    resize: vertical;
-}
-
 #oa-publicationform .oa-publicationform-details-form-file-heading {
     margin: 0;
 }
 
 #oa-publicationform textarea {
     resize: vertical;
+    min-height: 72px;
 }
 
 #oa-publicationform .twitter-typeahead,


### PR DESCRIPTION
You can't see text or scroll if you reduce the size of the comments box on the form to one line. This is only possible in Firefox. Chrome doesn't allow you to make the comments box smaller. We should have a fixed minimum size.
