### PR TITLE
'Find out more' link next to Addendum description doesn't line up

### DIFF
--- a/node_modules/oae-avocet/publicationform/publicationform.html
+++ b/node_modules/oae-avocet/publicationform/publicationform.html
@@ -92,7 +92,7 @@
                 </div>
 
                 <div class="form-group">
-                    <p>__MSG__USE_THE_CAMBRIDGE_ADDENDUM_TO__ <button type="button" class="oa-trigger-modaladdendum btn oa-link oa-btn-link oa-inline-btn-link oa-btn-form-help">__MSG__FIND_OUT_MORE__</button><br/><span data-widget="addendumlink" data-label="__MSG__DOWNLOAD_THE_CAMBRIDGE_ADDENDUM__"></span>
+                    <p>__MSG__USE_THE_CAMBRIDGE_ADDENDUM_TO__ <button type="button" class="oa-trigger-modaladdendum btn oa-link oa-btn-link oa-inline-btn-link">__MSG__FIND_OUT_MORE__</button><br/><span data-widget="addendumlink" data-label="__MSG__DOWNLOAD_THE_CAMBRIDGE_ADDENDUM__"></span>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
The 'Find out more' link next to the Addendum description is off by 1 or 2 pixels. 

![screen shot 2014-09-25 at 10 37 27](https://cloud.githubusercontent.com/assets/218391/4402432/963a0860-4497-11e4-975d-6b09805d4bf7.png)

All similar links should be checked and fixed.