### PR TITLE
Page descriptions

### DIFF
--- a/avocet/index.html
+++ b/avocet/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Open Access at Cambridge</title>
         <meta name="viewport" content="width=device-width">
-        <meta name="description" content="A service which helps University of Cambridge researchers meet HEFCE and funder Open Access policy requirements.">
+        <meta name="description" content="A service which helps University of Cambridge researchers meet HEFCE REF and funder Open Access policy requirements.">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <noscript>

--- a/avocet/upload.html
+++ b/avocet/upload.html
@@ -3,6 +3,7 @@
     <head>
         <title>Open Access at Cambridge</title>
         <meta name="viewport" content="width=device-width">
+        <meta name="description" content="Upload your manuscript to meet REF and other funder requirements.">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <noscript>

--- a/avocet/what-do-i-need-to-do.html
+++ b/avocet/what-do-i-need-to-do.html
@@ -3,6 +3,7 @@
     <head>
         <title>Open Access at Cambridge</title>
         <meta name="viewport" content="width=device-width">
+        <meta name="description" content="What Cambridge researchers need to do to meet HEFCE REF and other funders' Open Access policy requirements.">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <noscript>

--- a/avocet/what-is-changing.html
+++ b/avocet/what-is-changing.html
@@ -3,6 +3,7 @@
     <head>
         <title>Open Access at Cambridge</title>
         <meta name="viewport" content="width=device-width">
+        <meta name="description" content="Changes to Open Access policies which affect researchers at the University of Cambridge and their REF compliance.">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <noscript>

--- a/avocet/what-is-open-access.html
+++ b/avocet/what-is-open-access.html
@@ -3,6 +3,7 @@
     <head>
         <title>Open Access at Cambridge</title>
         <meta name="viewport" content="width=device-width">
+        <meta name="description" content="Information about Open Access publishing for University of Cambridge researchers.">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <noscript>


### PR DESCRIPTION
It might be worth adding description meta tags for the content pages (`/todo`, `/changing`, `/openaccess`). @timdegroote already added a meta tag for the home page (https://github.com/CUL-DigitalServices/avocet-ui/pull/213). Assigning to @micheleidesmith to determine what description we should use for the content pages if any.
