### PR TITLE
Noscript error page - wording needs updating

### DIFF
--- a/avocet/errors/noscript.html
+++ b/avocet/errors/noscript.html
@@ -8,18 +8,23 @@
 
         <link rel="stylesheet" href="/avocet/css/avocet.css">
         <link rel="stylesheet" href="/avocet/errors/css/avocet.error.css">
+
+        <script>
+            // If javascript is enabled, go to the homepage
+            window.location = '/';
+        </script>
     </head>
     <body style="display: block;">
         <header class="oa-panel-primary oa-error-banner">
             <div class="container">
-                <h2>JavaScript isn’t enabled: some things won’t run smoothly.</h2>
+                <h2>JavaScript isn’t enabled</h2>
             </div>
         </header>
 
         <section class="oa-error-section oa-section">
             <div class="container oa-error-container">
                 <img class="img-responsive center-block" src="/avocet/images/error.jpg" alt="Charles Darwin by Sir Quentin Blake">
-                <p>Without JavaScript some parts of the website will not work as intended. Please turn on JavaScript in your browser and refresh the page. If you need assistance, visit <a href="http://activatejavascript.org" title="More information about how to activate javascript in your web browser">http://activatejavascript.org</a>.</p>
+                <p>JavaScript must be enabled to use this site. Please turn on JavaScript in your browser and refresh the page. If you need assistance, please visit <a href="http://activatejavascript.org" title="More information about how to activate javascript in your web browser">http://activatejavascript.org</a>.</p>
             </div>
         </section>
     </body>


### PR DESCRIPTION
Needs updating as wording is not accurate - see issue raised in Bug Bash:

The /noscript page which shows when javascript is turned off has highly optimistic wording. It says "JavaScript isn’t enabled: some things won’t run smoothly" and "Without JavaScript some parts of the website will not work as intended". In fact NOTHING will work without javascript enabled, the user will only be able to see the /noscript page. The site requires javascript to work at all.
