### PR TITLE
'Select file' button in upload cloud doesn't follow button styling

### DIFF
--- a/node_modules/oae-avocet/submitpublication/css/submitpublication.css
+++ b/node_modules/oae-avocet/submitpublication/css/submitpublication.css
@@ -47,9 +47,10 @@
 
 #oa-submitpublication-upload .oa-submitpublication-btn-upload {
     border-radius: 4px;
-    font-size: .55em;
-    font-weight: bold;
+    font-size: 1em;
+    margin-top: 14px;
     overflow: hidden;
+    padding: 6px 36px;
     position: relative;
 }
 


### PR DESCRIPTION
The newly added 'select file' button in the upload area doesn't seem to match with the style of the rest of the page. Might just need tweaking so it's not bold? 
![screen shot 2014-09-25 at 10 24 31](https://cloud.githubusercontent.com/assets/6978428/4402240/c63f7c86-4495-11e4-8138-c35dee69ce13.png)

The preferred visual style can be found here: https://www.dropbox.com/s/psiglhom48ywfcp/choose%20file%20button.psd?dl=0 
