### PR TITLE
Updated Nginx config file for stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ node_modules/*
 !node_modules/oae-core
 !node_modules/oae-avocet
 
+stats/*
+
 target/
 
 tools/crowdin/*.jar

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,6 +53,27 @@ http {
     client_max_body_size 4096M;
 
 
+    ###############
+    ###############
+    ## DASHBOARD ##
+    ###############
+    ###############
+
+    ####################
+    ## LOAD BALANCING ##
+    ####################
+
+    server {
+        listen       80;
+        server_name  <%= nginxConf.NGINX_STATS %>;
+
+        location / {
+            alias <%= nginxConf.UX_HOME %>/stats/;
+            autoindex off;
+            expires max;
+        }
+    }
+
     ##################
     ##################
     ## GLOBAL ADMIN ##


### PR DESCRIPTION
Added a subdirectory for the statistics; stats.oae.com. This also needs a counterpart in Hilary and Puppet. The Puppet PR will contain a git clone command, since we don't want to include the entire Kibana/... codestack in our repository. The Hilary PR will contain some extra logging functionality.
