### PR TITLE
Case of "open access" incorrect in site navigation

### DIFF
--- a/node_modules/oae-avocet/avocetheader/js/avocetheader.js
+++ b/node_modules/oae-avocet/avocetheader/js/avocetheader.js
@@ -193,7 +193,7 @@
                     },
                     {
                         'href': '/what-is-open-access',
-                        'name': 'What is open access?'
+                        'name': 'What is Open Access?'
                     }
                 ]
             }


### PR DESCRIPTION
In the drop down nav menu the "What is open access?" link does not match the case of page's title which is "What is Open Access?".

Related to https://github.com/CUL-DigitalServices/avocet-ui/pull/199.
