### PR TITLE
Form post fails when entering a long manuscript name

### DIFF
--- a/node_modules/oae-avocet/publicationform/publicationform.html
+++ b/node_modules/oae-avocet/publicationform/publicationform.html
@@ -6,7 +6,7 @@
 
 <div id="oa-publicationform-form-template"><!--
     {macro inputField(name, placeholder, required)}
-        <input type="text" id="oa-publicationform-input-${name}" name="${name}" class="form-control{if required} required{/if}" value="${prefill[name]|encodeForHTMLAttribute}" {if !disabled}placeholder="${placeholder}"{else}disabled{/if}>
+        <input type="text" id="oa-publicationform-input-${name}" name="${name}" class="form-control{if required} required{/if}" value="${prefill[name]|encodeForHTMLAttribute}" {if !disabled}placeholder="${placeholder}"{else}disabled{/if} maxlength="1000">
     {/macro}
 
     {macro inputLabel(name, label, required, helpText, helpModalId, helpModalText)}


### PR DESCRIPTION
The request response text: `Missing or invalid displayName`

![screen shot 2014-10-03 at 10 16 18](https://cloud.githubusercontent.com/assets/1674142/4503885/0da2378c-4ade-11e4-8f05-0df194de5a68.png)
