### PR TITLE
Clicking back after uploading file then clicking to login again results in 404 error

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -255,6 +255,8 @@ http {
     server {
         listen   80 default_server;
 
+        # Redirect /me to the home page
+        rewrite ^/me$      / permanent;
 
         ######################
         ## SHARED RESOURCES ##


### PR DESCRIPTION
This is slightly odd behaviour from a user's perspective but I did this:
1. Logged in.
2. Uploaded file.
3. Clicked browser back button.
4. Clicked on Google login credentials again.
5. Got 404 page trying to access: http://ec2-54-73-99-234.eu-west-1.compute.amazonaws.com/me

I used Safari and Chrome. Happy to re-produce!
