### PR TITLE
Use Cassandra 1.2.16 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,15 @@ before_install:
   - echo 'yes' | sudo add-apt-repository ppa:coolwanglu/pdf2htmlex
   - sudo apt-get update
 
-  # Install cassandra 2.0.8 manually
+  # Install cassandra 1.2.16 manually
   - sudo service cassandra stop
-  - sudo apt-get install -y -o Dpkg::Options::=--force-confnew cassandra=2.0.8
+  - sudo apt-get install -y -o Dpkg::Options::=--force-confnew cassandra=1.2.16
   - sudo service cassandra start
   - sudo service cassandra status
 
   # Install nginx
-  - sudo apt-get install nginx
+  - sudo apt-get install nginx=1.7.6-1+precise1
+  - sudo service nginx stop
 
   # Turn off unneeded services to free some memory
   - sudo service mysql stop


### PR DESCRIPTION
Travis was using Cassandra version 2.0.8 on Travis which isn't compatible with our version of avocet-hilary.
This PR moves the Cassandra version back to 1.2.16.
